### PR TITLE
Add support for sending output to file

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -1,5 +1,7 @@
 require('ti-mocha');
 
+var runner;
+
 describe('ti-mocha', function() {
 
 	describe('suite 1', function() {
@@ -28,11 +30,72 @@ describe('ti-mocha', function() {
 
 });
 
-mocha.run(function() {
+Ti.API.info('');
+Ti.API.info('**** FIRST TESTS ****');
+Ti.API.info('');
+
+runner = mocha.run(function() {
 	Ti.API.info('This runtime test passed if the test suite ran and generated the following report: ');
 	Ti.API.info(JSON.stringify({
 		passed: 5,
 		pending: 2,
 		failed: 1
 	}, null, '  '));
+});
+
+runner.on('end', function() {
+	require('ti-mocha');
+
+	var outputFile;
+
+	describe('ti-mocha with file', function() {
+
+		describe('suite 1', function() {
+
+			it('this is a passing test', function(){});
+
+			it('this is a pending test');
+
+			it('this should fail', function() { throw new Error('I was supposed to fail'); });
+
+		});
+
+		describe('another suite', function() {
+
+			it('passing test 1', function(){});
+
+			it('passing test 2', function(){});
+
+			it('passing test 3', function(){});
+
+			it('passing test 4', function(){});
+
+			it('one more pending test');
+
+		});
+
+	});
+
+	outputFile = Titanium.Filesystem.getFile(Titanium.Filesystem.tempDirectory, 'test-reports.xml');
+	// if it already exists, clear it out and recreate it
+	if (outputFile.exists()) {
+		outputFile.deleteFile();
+	}
+	outputFile.createFile();
+
+	mocha.setup({
+		reporter: 'xunit',
+		outputFile: outputFile
+	});
+
+	Ti.API.info('');
+	Ti.API.info('**** SECOND TESTS ****');
+	Ti.API.info('');
+
+	mocha.run(function() {
+		Ti.API.info('');
+		Ti.API.info('This runtime test passed if the test suite ran and generated the following report: ');
+		Ti.API.info('tests="8" failures="1" errors="1" skipped="2"');
+		Ti.API.info('And the report shown above was contained in the file: ' + Titanium.Filesystem.tempDirectory + 'test-reports.xml');
+	});
 });


### PR DESCRIPTION
In some situations its necessary to have the mocha output sent to a
file rather than just showing on the console.  For instance, when using
Jenkins as a continuous integration server to run the Titanium builds,
one must use a reporter such as XUnit and redirect the output to a file
which Jenkins can then read once the tests are complete, and report
back to the user.  In order to accomplish this, titanium.js was
modified to accept an “outputFile” setup option which, if present, will
be used to send console output.  Since the reporters send the test
results to console, these messages will then be additionally appended
to the file.

Also, to give the user ability to listen to events on the mocha runner,
return the runner on the call to run the tests.  This can be used to
listen for the “end” event which would notify the user that all tests
are complete.  This is also important in continuous integration to
notify when the simulator is finished running the tests.

Tests were added to the existing app.js test to verify messages were
written to a file and the events are available through the returned
runner.
