### PR TITLE
Added a log watcher so that 3rd party tools can consume ti-mocha test result output.

### DIFF
--- a/lib/log-watcher.js
+++ b/lib/log-watcher.js
@@ -1,0 +1,46 @@
+/**
+ * Watches log output from the iOS Simulator and an iOS device for test results,
+ * then fires the callback with the results.
+ *
+ * @copyright
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ *
+ * @license
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+/**
+ * Watches log output for ti-mocha test results.
+ *
+ * @param {EventEmitter} emitter - The iOS Simulator or iOS device event emitter.
+ * @param {Function} [callback(err, results)] - A function to call with the test results.
+ */
+module.exports = function logWatcher(emitter, callback) {
+	typeof callback === 'function' || (callback = function () {});
+
+	var inTiMochaResult = false,
+		tiMochaResults = [],
+		logLevelRegExp = /^\[\w+\]\s*/;
+
+	function watch(line) {
+		line = line.replace(logLevelRegExp, '');
+
+		if (line === 'TI_MOCHA_RESULT_START') {
+			inTiMochaResult = true;
+		} else if (inTiMochaResult && line === 'TI_MOCHA_RESULT_STOP') {
+			emitter.removeListener('log', watch);
+			emitter.removeListener('logFile', watch);
+			try {
+				callback(null, tiMochaResults.length ? JSON.parse(tiMochaResults.join('\n').trim()) : {});
+			} catch (ex) {
+				callback(new Error('Results are not valid JSON'));
+			}
+		} else if (inTiMochaResult && line) {
+			tiMochaResults.push(line);
+		}
+	}
+
+	emitter.on('log', watch);
+	emitter.on('logFile', watch);
+};


### PR DESCRIPTION
The rationale is that we want to decouple the ti-mocha output format from tools that run ti-mocha tests.

The design is such that we pass every line of output from an iOS device or simulator to this log-watcher, then it handles all of the test result formatting and parsing. Once the log-watcher it has extracted all of the results, it fires the callback with a JavaScript object containing the results.

This change is needed for the `tio2` module and the `ioslib` module. `ioslib` does not use ti-mocha itself, but does use it in its tests.

P.S. Please version bump ti-mocha to 0.1.4 and publish to npm. Gracias! :)
