### PR TITLE
Improve error (spec failure) output for iOS environment

### DIFF
--- a/ti-mocha.js
+++ b/ti-mocha.js
@@ -2158,11 +2158,18 @@ exports.list = function(failures){
     var err = test.err
       , message = err.message || ''
       , stack = err.stack || message
-      , index = stack.indexOf(message) + message.length
-      , msg = stack.slice(0, index)
+      , index = stack.indexOf(message)
       , actual = err.actual
       , expected = err.expected
       , escape = true;
+    if (index === -1) {
+        msg = message;
+    } else {
+      index += message.length;
+      msg = stack.slice(0, index);
+      // remove msg from stack
+      stack = stack.slice(index + 1);
+    }
 
     // uncaught
     if (err.uncaught) {
@@ -2190,8 +2197,7 @@ exports.list = function(failures){
     }
 
     // indent stack trace without msg
-    stack = stack.slice(index ? index + 1 : index)
-      .replace(/^/gm, '  ');
+    stack = stack.replace(/^/gm, '  ');
 
     console.error(fmt, (i + 1), test.fullTitle(), msg, stack);
   });


### PR DESCRIPTION
Hi,

I've noticed that when using ti-mocha in iOS environment the error message part doesn't show when spec finished running.

This is because the current version of ti-mocha assumes the first line of `err.stack` is the same as `err.message` but this isn't the case in titanium's iOS environment.

After looking around a while, I found that original mocha already fixed this issue on [mocha #1631](https://github.com/mochajs/mocha/pull/1631) and this is the port of that PR. This must improve titanium iOS env output as well.

Thanks,
